### PR TITLE
Horizontal pager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.ui)
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
+    implementation(libs.ui.util)
     implementation(libs.material3)
     implementation(libs.navigation.compose)
     testImplementation(libs.junit)

--- a/app/src/main/java/com/handysparksoft/ainimations/AiNimationsApp.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/AiNimationsApp.kt
@@ -39,6 +39,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.handysparksoft.ainimations.components.AiNimationsHorizontalPager
 import com.handysparksoft.ainimations.components.ColumnWithCenteredContent
 import com.handysparksoft.ainimations.ui.theme.AiNimationsTheme
 
@@ -159,7 +160,9 @@ fun ComponentAnimationsScreenMock(
     ColumnWithCenteredContent(
         modifier = modifier
     ) {
-        Text(text = "Component Animations Screen")
+        AiNimationsHorizontalPager {
+            Text(text = "Sample Animation")
+        }
     }
 }
 

--- a/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsCard.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsCard.kt
@@ -1,0 +1,173 @@
+package com.handysparksoft.ainimations.components
+
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.handysparksoft.ainimations.R
+import com.handysparksoft.ainimations.ui.theme.AiNimationsTheme
+import kotlin.math.absoluteValue
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun AiNimationsCard(
+    pagerState: PagerState,
+    page: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val cardRadius = 24.dp
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .shadow(16.dp, ambientColor = Color.LightGray),
+        shape = RoundedCornerShape(cardRadius)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(24.dp)
+        ) {
+            val pageOffset = ((pagerState.currentPage - page) + pagerState.currentPageOffsetFraction).absoluteValue
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .aspectRatio(ANIMATION_BOX_ASPECT_RATIO)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(cardRadius)
+                    )
+                    .clipToBounds()
+            ) {
+                Box(
+                    modifier = Modifier.graphicsLayer {
+                        val scale = lerp(1f, 2f, pageOffset)
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                ) {
+                    content()
+                }
+            }
+            Spacer(modifier = Modifier.size(24.dp))
+            AiNimationDetails()
+            AiNimationDragToReplay(pageOffset = pageOffset, onDrag = {
+                Toast.makeText(context, "Replay", Toast.LENGTH_SHORT).show()
+            })
+        }
+    }
+}
+
+@Composable
+private fun AiNimationDetails(modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.padding(16.dp)
+    ) {
+        Text(text = "Title", style = MaterialTheme.typography.headlineLarge)
+        Text(text = "Subtitle", style = MaterialTheme.typography.titleSmall)
+    }
+}
+
+@Composable
+private fun AiNimationDragToReplay(
+    pageOffset: Float,
+    onDrag: () -> Unit = {}
+) {
+    var offsetY by remember { mutableStateOf(0f) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp * (1 - pageOffset))
+            .graphicsLayer {
+                alpha = 1 - pageOffset
+            }
+            .draggable(
+                orientation = Orientation.Vertical,
+                state = rememberDraggableState { delta ->
+                    val deltaFactor = 10
+                    offsetY += delta / deltaFactor
+                },
+                onDragStopped = {
+                    onDrag()
+                    offsetY = 0f
+                }
+            )
+            .offset(x = 0.dp, y = offsetY.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.PlayArrow,
+                contentDescription = "Drag to Replay",
+                modifier = Modifier.size(36.dp)
+            )
+            Text(
+                text = stringResource(id = R.string.drag_to_replay).uppercase(),
+                style = MaterialTheme.typography.labelSmall
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "Drag to Replay")
+        }
+    }
+}
+
+private const val ANIMATION_BOX_ASPECT_RATIO = 1.2f
+
+@OptIn(ExperimentalFoundationApi::class)
+@Preview
+@Composable
+internal fun AiNimationsCardPreview() {
+    val pagerState = rememberPagerState()
+    AiNimationsTheme {
+        AiNimationsCard(pagerState = pagerState, page = 0) {
+            Text(text = "Sample AiNimation")
+        }
+    }
+}

--- a/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
@@ -1,11 +1,14 @@
 package com.handysparksoft.ainimations.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -18,20 +21,29 @@ fun AiNimationsHorizontalPager(
     content: @Composable () -> Unit
 ) {
     val pagerState = rememberPagerState()
-    val items = listOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+    val pages = listOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
 
-    HorizontalPager(
-        pageCount = items.size,
-        pageSpacing = 16.dp,
-        beyondBoundsPageCount = 2,
-        state = pagerState,
-        modifier = modifier
-    ) { page ->
-        AiNimationsCard(
-            pagerState = pagerState,
-            page = page,
-            modifier = Modifier.padding(horizontal = 64.dp, vertical = 32.dp),
-            content = content
+    Box(modifier = modifier.fillMaxSize()) {
+        HorizontalPager(
+            pageCount = pages.size,
+            pageSpacing = 16.dp,
+            beyondBoundsPageCount = 2,
+            state = pagerState
+        ) { page ->
+            AiNimationsCard(
+                pagerState = pagerState,
+                page = page,
+                modifier = Modifier.padding(horizontal = 64.dp, vertical = 48.dp),
+                content = content
+            )
+        }
+
+        PageIndicator(
+            pageCount = pages.size,
+            selectedPage = pagerState.currentPage,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(12.dp)
         )
     }
 }

--- a/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
@@ -1,41 +1,15 @@
 package com.handysparksoft.ainimations.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.lerp
-import com.handysparksoft.ainimations.R
 import com.handysparksoft.ainimations.ui.theme.AiNimationsTheme
-import kotlin.math.absoluteValue
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -53,7 +27,7 @@ fun AiNimationsHorizontalPager(
         state = pagerState,
         modifier = modifier
     ) { page ->
-        AiNimationCard(
+        AiNimationsCard(
             pagerState = pagerState,
             page = page,
             modifier = Modifier.padding(horizontal = 64.dp, vertical = 32.dp),
@@ -62,102 +36,9 @@ fun AiNimationsHorizontalPager(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun AiNimationCard(
-    pagerState: PagerState,
-    page: Int,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
-) {
-    val cardRadius = 24.dp
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-            .shadow(16.dp, ambientColor = Color.LightGray),
-        shape = RoundedCornerShape(cardRadius)
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .padding(24.dp)
-        ) {
-            val pageOffset = ((pagerState.currentPage - page) + pagerState.currentPageOffsetFraction).absoluteValue
-
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .aspectRatio(ANIMATION_BOX_ASPECT_RATIO)
-                    .border(
-                        width = 1.dp,
-                        color = MaterialTheme.colorScheme.outline,
-                        shape = RoundedCornerShape(cardRadius)
-                    )
-                    .clipToBounds()
-            ) {
-                Box(
-                    modifier = Modifier.graphicsLayer {
-                        val scale = lerp(1f, 2f, pageOffset)
-                        scaleX = scale
-                        scaleY = scale
-                    }
-                ) {
-                    content()
-                }
-            }
-            Spacer(modifier = Modifier.size(24.dp))
-            AiNimationDetails()
-            AiNimationDragToReplay(pageOffset = pageOffset)
-        }
-    }
-}
-
-@Composable
-private fun AiNimationDetails(modifier: Modifier = Modifier) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.padding(16.dp)
-    ) {
-        Text(text = "Title", style = MaterialTheme.typography.titleLarge)
-        Text(text = "Subtitle", style = MaterialTheme.typography.titleSmall)
-    }
-}
-
-@Composable
-private fun AiNimationDragToReplay(pageOffset: Float) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(100.dp * (1 - pageOffset))
-            .graphicsLayer {
-                alpha = 1 - pageOffset
-            }
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.align(Alignment.BottomCenter)
-        ) {
-            Icon(
-                imageVector = Icons.Filled.PlayArrow,
-                contentDescription = "Drag to Replay",
-                modifier = Modifier.size(36.dp)
-            )
-            Text(
-                text = stringResource(id = R.string.drag_to_replay).uppercase(),
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Spacer(modifier = Modifier.size(8.dp))
-            Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "Drag to Replay")
-        }
-    }
-}
-
-private const val ANIMATION_BOX_ASPECT_RATIO = 1.2f
-
 @Preview
 @Composable
-fun HorizontalPagerPreview() {
+internal fun HorizontalPagerPreview() {
     AiNimationsTheme {
         AiNimationsHorizontalPager {
             Text(text = "Sample Content")

--- a/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsHorizontalPager.kt
@@ -1,0 +1,166 @@
+package com.handysparksoft.ainimations.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.handysparksoft.ainimations.R
+import com.handysparksoft.ainimations.ui.theme.AiNimationsTheme
+import kotlin.math.absoluteValue
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun AiNimationsHorizontalPager(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val pagerState = rememberPagerState()
+    val items = listOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+
+    HorizontalPager(
+        pageCount = items.size,
+        pageSpacing = 16.dp,
+        beyondBoundsPageCount = 2,
+        state = pagerState,
+        modifier = modifier
+    ) { page ->
+        AiNimationCard(
+            pagerState = pagerState,
+            page = page,
+            modifier = Modifier.padding(horizontal = 64.dp, vertical = 32.dp),
+            content = content
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun AiNimationCard(
+    pagerState: PagerState,
+    page: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val cardRadius = 24.dp
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .shadow(16.dp, ambientColor = Color.LightGray),
+        shape = RoundedCornerShape(cardRadius)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(24.dp)
+        ) {
+            val pageOffset = ((pagerState.currentPage - page) + pagerState.currentPageOffsetFraction).absoluteValue
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .aspectRatio(ANIMATION_BOX_ASPECT_RATIO)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(cardRadius)
+                    )
+                    .clipToBounds()
+            ) {
+                Box(
+                    modifier = Modifier.graphicsLayer {
+                        val scale = lerp(1f, 2f, pageOffset)
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                ) {
+                    content()
+                }
+            }
+            Spacer(modifier = Modifier.size(24.dp))
+            AiNimationDetails()
+            AiNimationDragToReplay(pageOffset = pageOffset)
+        }
+    }
+}
+
+@Composable
+private fun AiNimationDetails(modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.padding(16.dp)
+    ) {
+        Text(text = "Title", style = MaterialTheme.typography.titleLarge)
+        Text(text = "Subtitle", style = MaterialTheme.typography.titleSmall)
+    }
+}
+
+@Composable
+private fun AiNimationDragToReplay(pageOffset: Float) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp * (1 - pageOffset))
+            .graphicsLayer {
+                alpha = 1 - pageOffset
+            }
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.PlayArrow,
+                contentDescription = "Drag to Replay",
+                modifier = Modifier.size(36.dp)
+            )
+            Text(
+                text = stringResource(id = R.string.drag_to_replay).uppercase(),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "Drag to Replay")
+        }
+    }
+}
+
+private const val ANIMATION_BOX_ASPECT_RATIO = 1.2f
+
+@Preview
+@Composable
+fun HorizontalPagerPreview() {
+    AiNimationsTheme {
+        AiNimationsHorizontalPager {
+            Text(text = "Sample Content")
+        }
+    }
+}

--- a/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsPageIndicator.kt
+++ b/app/src/main/java/com/handysparksoft/ainimations/components/AiNimationsPageIndicator.kt
@@ -1,0 +1,44 @@
+package com.handysparksoft.ainimations.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun PageIndicator(
+    pageCount: Int,
+    selectedPage: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier) {
+        repeat(pageCount) {
+            val isSelectedPage = it == selectedPage
+            val dotColor = getDotColor(isSelectedPage = isSelectedPage)
+            Dot(color = dotColor)
+        }
+    }
+}
+
+@Composable
+private fun getDotColor(isSelectedPage: Boolean) = when {
+    isSelectedPage -> MaterialTheme.colorScheme.secondaryContainer
+    else -> MaterialTheme.colorScheme.outline
+}
+
+@Composable
+private fun Dot(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(16.dp)
+            .padding(4.dp)
+            .background(color = color, shape = CircleShape)
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="share_text">Check the AiNimations source code at https://github.com/davidasensio/AiNimations</string>
 
     <string name="back">Back</string>
+    <string name="drag_to_replay">Drag to Replay</string>
 </resources>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -586,12 +586,12 @@ style:
       - '2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
-    ignoreLocalVariableDeclaration: false
+    ignoreLocalVariableDeclaration: true
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
-    ignoreAnnotation: false
+    ignoreAnnotation: true
     ignoreNamedArgument: true
-    ignoreEnums: false
+    ignoreEnums: true
     ignoreRanges: false
     ignoreExtensionFunctions: true
   MandatoryBracesIfStatements:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ activity-compose = { group = "androidx.activity", name = "activity-compose", ver
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 ui = { group = "androidx.compose.ui", name = "ui" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
## Description 📋

This pull request implements the `HorizontalPager` functionality to display the AiNimations, including a Drag zone in the `AiNimationCard` composable that will allow to replay an animation and also a `PageIndicator` composable


See:
- [Inspiration post from Rebecca Franks](https://medium.com/androiddevelopers/customizing-compose-pager-with-fun-indicators-and-transitions-12b3b69af2cc)
- [Drag Gesture](https://developer.android.com/jetpack/compose/touch-input/pointer-input/drag-swipe-fling)
- [Page Indicators - Official Docs](https://developer.android.com/jetpack/compose/layouts/pager#add-page)


## Type of change ⚙️

- [X] New feature
- [ ] Bug fix
- [ ] Architecture
- [ ] Documentation

## Screenshots 📸


<img src="https://github.com/davidasensio/AiNimations/assets/11421976/c40f505d-ac5c-4c7a-bb6f-dd0588dd4e9e" width=300px>


## Testing 🛡

<If you did not add tests explain why>

- [ ] Unit tests added
- [ ] UI Espresso tests added


